### PR TITLE
init nsib

### DIFF
--- a/R/Example/example.R
+++ b/R/Example/example.R
@@ -6,6 +6,7 @@ library(progress)
 N = 5000
 h2 = .5
 nthreads = 6  # number of threads to use for ltfh++
+nsib = 0
 
 #calculates the thresholds used to determine status:
 K = .05

--- a/R/Example/example_multi.R
+++ b/R/Example/example_multi.R
@@ -9,6 +9,7 @@ gen_cor = .5
 corr_mat = diag(c(h2_1, h2_2))
 corr_mat[1,2] <- corr_mat[2,1] <- gen_cor
 nthreads = 6  # number of threads to use for ltfh++
+nsib = 0
 
 #calculates the thresholds used to determine status:
 K = .05

--- a/R/Example/example_nosib.R
+++ b/R/Example/example_nosib.R
@@ -9,6 +9,7 @@ library(gridExtra)
 N = 5000 
 h2 = .5 
 nthreads = 6  # number of threads to use for ltfh++
+nsib = 0
 
 #calculates the thresholds used to determine status:
 K = .05
@@ -18,7 +19,7 @@ prev = c(0.08, .02) * multiplier
 
 #### THE NEXT SECTION REQUIRES YOU TO HAVE THE SOURCE CODE FOR LT-FH LOADED OR SOURCING IT ####
 source("C:/Code/LTFH/assign_ltfh.R")
-
+## download from here: https://alkesgroup.broadinstitute.org/UKBB/LTFH/
 
 #constructs covariance matrix with a baseling of 2 parents and n_sib siblings (with-in disorder):
 get_cov = function(h2, n_sib = 0) {


### PR DESCRIPTION
- `nsib` was not defined, so set it to 0 in all example scripts. 
- added link to point to ltfh software